### PR TITLE
Ajout d'un lien vers les GitHub issues pour les problèmes

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,10 @@
             <li>Paquets <small>Mis à jours chaque 2 heures</small> <a href="/archlinux/">HTTP</a></li>
         </ul>
         <p>
-            Besoin d'un autre mirroir? <a href="mailto:clubcedille@gmail.com">Contactez-nous!</a>
+            Besoin d'un autre miroir? <a href="mailto:clubcedille@gmail.com">Contactez-nous!</a>
+        </p>
+        <p>
+            Il y a un problème avec nos miroirs? <a href="https://github.com/ClubCedille/mirrors/issues">Faites-le nous savoir.</a>
         </p>
         <br>
         <img src="/img/Cedille.png" style="width:10em;">

--- a/index_en.html
+++ b/index_en.html
@@ -37,6 +37,9 @@
         <p>
             Need another mirror? <a href="mailto:clubcedille@gmail.com">Contact us!</a>
         </p>
+        <p>
+            There's an issue with the mirrors? <a href="https://github.com/ClubCedille/mirrors/issues">Let us know.</a>
+        </p>
         <br>
         <img src="/img/Cedille.png" style="width:10em;">
     </body>


### PR DESCRIPTION
Un lien a été ajouté vers les GitHub issues sur la page index du site. On veut que les utilisateurs puissent nous avertir facilement des problèmes qu'ils rencontrent. Cela leur donne plus de chance de réussir à nous contacter. 

J'ai aussi corrigé `mirroir` --> `miroir`, car deux `r` c'est comme en anglais, mais ça s'écrit pas comme ça en français. 