### PR TITLE
Fix rsync endpoint for ubuntu releases

### DIFF
--- a/scripts/ubuntu_releases
+++ b/scripts/ubuntu_releases
@@ -7,4 +7,4 @@ BASEDIR=/media/mirror/ubuntu/releases/
 ./base_releases "${RSYNCSOURCE}" "${BASEDIR}" || exit 1
 
 host=$(/bin/hostname -f)
-date -u > "${BASEDIR}/project/trace/${host}" || exit 2
+date -u > "${BASEDIR}/.trace/${host}" || exit 2

--- a/scripts/ubuntu_releases
+++ b/scripts/ubuntu_releases
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # Mirror Ubuntu releases directory
 
-RSYNCSOURCE=rsync://ca.rsync.releases.ubuntu.com/releases
+RSYNCSOURCE=rsync://ca.rsync.releases.ubuntu.com/ubuntu-releases
 BASEDIR=/media/mirror/ubuntu/releases/
 
 ./base_releases "${RSYNCSOURCE}" "${BASEDIR}" || exit 1


### PR DESCRIPTION
The rsync endpoint for ubuntu releases changed and the ubuntu releases haven't synced in a long time.